### PR TITLE
Netbsd ppc

### DIFF
--- a/xpcom/reflect/xptcall/genstubs.pl
+++ b/xpcom/reflect/xptcall/genstubs.pl
@@ -44,7 +44,7 @@ print OUTFILE "*  0 is QueryInterface\n";
 print OUTFILE "*  1 is AddRef\n";
 print OUTFILE "*  2 is Release\n";
 print OUTFILE "*/\n";
-print OUTFILE "#if !defined(__ia64) || (!defined(__hpux) && !defined(__linux__) && !defined(__FreeBSD__))\n";
+print OUTFILE "#if !defined(__ia64) || (!defined(__hpux) && !defined(__linux__) && !defined(__FreeBSD__) && !defined(__NetBSD__))\n";
 for($i = 0; $i < $entry_count; $i++) {
     print OUTFILE "NS_IMETHOD Stub",$i+3,"();\n";
 }

--- a/xpcom/reflect/xptcall/md/unix/moz.build
+++ b/xpcom/reflect/xptcall/md/unix/moz.build
@@ -215,13 +215,14 @@ if CONFIG['OS_TEST'] in ('powerpc64', 'powerpc64le'):
               'xptcstubs_ppc64_linux.cpp',
           ]
 
-if CONFIG['OS_TEST'] in ('macppc', 'bebox', 'ofppc', 'prep', 'amigappc'):
+# OpenBSD/powerpc MD code is up to date and fits NetBSD
+if CONFIG['OS_TEST'] in ('powerpc', 'macppc', 'bebox', 'ofppc', 'prep', 'amigappc'):
     if CONFIG['OS_ARCH'] == 'NetBSD':
         SOURCES += [
-            'xptcinvoke_asm_ppc_netbsd.s',
-            'xptcinvoke_ppc_netbsd.cpp',
-            'xptcstubs_asm_ppc_netbsd.s',
-            'xptcstubs_ppc_netbsd.cpp',
+            'xptcinvoke_asm_ppc_openbsd.S',
+            'xptcinvoke_ppc_openbsd.cpp',
+            'xptcstubs_asm_ppc_openbsd.S',
+            'xptcstubs_ppc_openbsd.cpp',
         ]
 
 if CONFIG['OS_ARCH'] == 'OpenBSD' and CONFIG['OS_TEST'] == 'powerpc':

--- a/xpcom/reflect/xptcall/md/unix/xptcinvoke_arm_netbsd.cpp
+++ b/xpcom/reflect/xptcall/md/unix/xptcinvoke_arm_netbsd.cpp
@@ -101,7 +101,8 @@ struct my_params_struct {
     uint32_t fn_copy;      
 };
 
-XPTC_PUBLIC_API(nsresult)
+
+EXPORT_XPCOM_API(nsresult)
 XPTC_InvokeByIndex(nsISupports* that, uint32_t methodIndex,
                    uint32_t paramCount, nsXPTCVariant* params)
 {

--- a/xpcom/reflect/xptcall/md/unix/xptcinvoke_ppc_netbsd.cpp
+++ b/xpcom/reflect/xptcall/md/unix/xptcinvoke_ppc_netbsd.cpp
@@ -110,6 +110,6 @@ invoke_copy_to_stack(uint32_t* d,
 }
 
 extern "C"
-XPTC_PUBLIC_API(nsresult)
+EXPORT_XPCOM_API(nsresult)
 XPTC_InvokeByIndex(nsISupports* that, uint32_t methodIndex,
                    uint32_t paramCount, nsXPTCVariant* params);

--- a/xpcom/reflect/xptcall/md/unix/xptcstubs_netbsd_m68k.cpp
+++ b/xpcom/reflect/xptcall/md/unix/xptcstubs_netbsd_m68k.cpp
@@ -6,6 +6,7 @@
 /* Implement shared vtbl methods. */
 
 #include "xptcprivate.h"
+#include "xptiprivate.h"
 
 #if !defined(__NetBSD__) || !defined(__m68k__)
 #error This code is for NetBSD/m68k only
@@ -19,19 +20,17 @@ extern "C" {
 
         nsXPTCMiniVariant paramBuffer[PARAM_BUFFER_COUNT];
         nsXPTCMiniVariant* dispatchParams = nullptr;
-        nsIInterfaceInfo* iface_info = nullptr;
-        const nsXPTMethodInfo* info;
+        const nsXPTMethodInfo* info = nullptr;
         uint8_t paramCount;
         uint8_t i;
         nsresult result = NS_ERROR_FAILURE;
 
         NS_ASSERTION(self,"no self");
 
-        self->GetInterfaceInfo(&iface_info);
-        NS_ASSERTION(iface_info,"no interface info");
-
-        iface_info->GetMethodInfo(uint16_t(methodIndex), &info);
-        NS_ASSERTION(info,"no interface info");
+        self->mEntry->GetMethodInfo(uint16_t(methodIndex), &info);
+        NS_ASSERTION(info,"no method info");
+        if (!info)
+            return NS_ERROR_UNEXPECTED;
 
         paramCount = info->GetParamCount();
 
@@ -80,9 +79,7 @@ extern "C" {
             }
         }
 
-        result = self->CallMethod((uint16_t)methodIndex, info, dispatchParams);
-
-        NS_RELEASE(iface_info);
+        result = self->mOuter->CallMethod((uint16_t)methodIndex, info, dispatchParams);
 
         if(dispatchParams != paramBuffer)
             delete [] dispatchParams;

--- a/xpcom/reflect/xptcall/md/unix/xptcstubs_ppc_linux.cpp
+++ b/xpcom/reflect/xptcall/md/unix/xptcstubs_ppc_linux.cpp
@@ -49,6 +49,11 @@ PrepareAndDispatch(nsXPTCStubBase* self,
 
     self->mEntry->GetMethodInfo(uint16_t(methodIndex), &info);
     NS_ASSERTION(info,"no method info");
+    if (!info)
+        return NS_ERROR_UNEXPECTED;
+
+    iface_info->GetMethodInfo(uint16_t(methodIndex), &info);
+    NS_ASSERTION(info,"no method info");
     if (! info)
         return NS_ERROR_UNEXPECTED;
 

--- a/xpcom/reflect/xptcall/md/unix/xptcstubs_ppc_netbsd.cpp
+++ b/xpcom/reflect/xptcall/md/unix/xptcstubs_ppc_netbsd.cpp
@@ -6,6 +6,7 @@
 // Implement shared vtbl methods.
 
 #include "xptcprivate.h"
+#include "xptiprivate.h"
 
 // The Linux/PPC ABI (aka PPC/SYSV ABI) passes the first 8 integral
 // parameters and the first 8 floating point parameters in registers
@@ -36,22 +37,16 @@ PrepareAndDispatch(nsXPTCStubBase* self,
 {
     nsXPTCMiniVariant paramBuffer[PARAM_BUFFER_COUNT];
     nsXPTCMiniVariant* dispatchParams = nullptr;
-    nsIInterfaceInfo* iface_info = nullptr;
-    const nsXPTMethodInfo* info;
+    const nsXPTMethodInfo* info = nullptr;
     uint32_t paramCount;
     uint32_t i;
     nsresult result = NS_ERROR_FAILURE;
 
     NS_ASSERTION(self,"no self");
 
-    self->GetInterfaceInfo(&iface_info);
-    NS_ASSERTION(iface_info,"no interface info");
-    if (! iface_info)
-        return NS_ERROR_UNEXPECTED;
-
-    iface_info->GetMethodInfo(uint16_t(methodIndex), &info);
+    self->mEntry->GetMethodInfo(uint16_t(methodIndex), &info);
     NS_ASSERTION(info,"no method info");
-    if (! info)
+    if (!info)
         return NS_ERROR_UNEXPECTED;
 
     paramCount = info->GetParamCount();
@@ -147,9 +142,7 @@ PrepareAndDispatch(nsXPTCStubBase* self,
         }
     }
 
-    result = self->CallMethod((uint16_t) methodIndex, info, dispatchParams);
-
-    NS_RELEASE(iface_info);
+    result = self->mOuter->CallMethod((uint16_t) methodIndex, info, dispatchParams);
 
     if (dispatchParams != paramBuffer)
         delete [] dispatchParams;

--- a/xpcom/reflect/xptcall/md/unix/xptcstubs_sparc_netbsd.cpp
+++ b/xpcom/reflect/xptcall/md/unix/xptcstubs_sparc_netbsd.cpp
@@ -6,6 +6,7 @@
 /* Implement shared vtbl methods. */
 
 #include "xptcprivate.h"
+#include "xptiprivate.h"
 
 #if defined(sparc) || defined(__sparc__)
 
@@ -23,19 +24,17 @@ PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args)
 
     nsXPTCMiniVariant paramBuffer[PARAM_BUFFER_COUNT];
     nsXPTCMiniVariant* dispatchParams = nullptr;
-    nsIInterfaceInfo* iface_info = nullptr;
-    const nsXPTMethodInfo* info;
+    const nsXPTMethodInfo* info = nullptr;
     uint8_t paramCount;
     uint8_t i;
     nsresult result = NS_ERROR_FAILURE;
 
     NS_ASSERTION(self,"no self");
 
-    self->GetInterfaceInfo(&iface_info);
-    NS_ASSERTION(iface_info,"no interface info");
-
-    iface_info->GetMethodInfo(uint16_t(methodIndex), &info);
-    NS_ASSERTION(info,"no interface info");
+    self->mEntry->GetMethodInfo(uint16_t(methodIndex), &info);
+    NS_ASSERTION(info,"no method info");
+    if (!info)
+        return NS_ERROR_UNEXPECTED;
 
     paramCount = info->GetParamCount();
 
@@ -86,9 +85,7 @@ PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args)
         }
     }
 
-    result = self->CallMethod((uint16_t)methodIndex, info, dispatchParams);
-
-    NS_RELEASE(iface_info);
+    result = self->oMouter->CallMethod((uint16_t)methodIndex, info, dispatchParams);
 
     if(dispatchParams != paramBuffer)
         delete [] dispatchParams;

--- a/xpcom/reflect/xptcall/md/unix/xptcstubs_sparc_openbsd.cpp
+++ b/xpcom/reflect/xptcall/md/unix/xptcstubs_sparc_openbsd.cpp
@@ -6,6 +6,7 @@
 /* Implement shared vtbl methods. */
 
 #include "xptcprivate.h"
+#include "xptiprivate.h"
 
 #if defined(sparc) || defined(__sparc__)
 
@@ -23,19 +24,17 @@ PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args)
 
     nsXPTCMiniVariant paramBuffer[PARAM_BUFFER_COUNT];
     nsXPTCMiniVariant* dispatchParams = nullptr;
-    nsIInterfaceInfo* iface_info = nullptr;
-    const nsXPTMethodInfo* info;
+    const nsXPTMethodInfo* info = nullptr;
     uint8_t paramCount;
     uint8_t i;
     nsresult result = NS_ERROR_FAILURE;
 
     NS_ASSERTION(self,"no self");
 
-    self->GetInterfaceInfo(&iface_info);
-    NS_ASSERTION(iface_info,"no interface info");
-
-    iface_info->GetMethodInfo(uint16_t(methodIndex), &info);
-    NS_ASSERTION(info,"no interface info");
+    self->mEntry->GetMethodInfo(uint16_t(methodIndex), &info);
+    NS_ASSERTION(info,"no method info");
+    if (!info)
+        return NS_ERROR_UNEXPECTED;
 
     paramCount = info->GetParamCount();
 
@@ -89,9 +88,7 @@ PrepareAndDispatch(nsXPTCStubBase* self, uint32_t methodIndex, uint32_t* args)
         }
     }
 
-    result = self->CallMethod((uint16_t)methodIndex, info, dispatchParams);
-
-    NS_RELEASE(iface_info);
+    result = self->mOuter->CallMethod((uint16_t)methodIndex, info, dispatchParams);
 
     if(dispatchParams != paramBuffer)
         delete [] dispatchParams;

--- a/xpcom/reflect/xptcall/xptcprivate.h
+++ b/xpcom/reflect/xptcall/xptcprivate.h
@@ -14,7 +14,7 @@
 
 class xptiInterfaceEntry;
 
-#if !defined(__ia64) || (!defined(__hpux) && !defined(__linux__) && !defined(__FreeBSD__))
+#if !defined(__ia64) || (!defined(__hpux) && !defined(__linux__) && !defined(__FreeBSD__) && !defined(__NetBSD__))
 #define STUB_ENTRY(n) NS_IMETHOD Stub##n() = 0;
 #else
 #define STUB_ENTRY(n) NS_IMETHOD Stub##n(uint64_t,uint64_t,uint64_t,uint64_t,uint64_t,uint64_t,uint64_t,uint64_t) = 0;
@@ -31,7 +31,7 @@ public:
 #undef STUB_ENTRY
 #undef SENTINEL_ENTRY
 
-#if !defined(__ia64) || (!defined(__hpux) && !defined(__linux__) && !defined(__FreeBSD__))
+#if !defined(__ia64) || (!defined(__hpux) && !defined(__linux__) && !defined(__FreeBSD__) && !defined(__NetBSD__))
 #define STUB_ENTRY(n) NS_IMETHOD Stub##n() override;
 #else
 #define STUB_ENTRY(n) NS_IMETHOD Stub##n(uint64_t,uint64_t,uint64_t,uint64_t,uint64_t,uint64_t,uint64_t,uint64_t) override;

--- a/xpcom/reflect/xptcall/xptcstubsdecl.inc
+++ b/xpcom/reflect/xptcall/xptcstubsdecl.inc
@@ -8,7 +8,7 @@
 *  1 is AddRef
 *  2 is Release
 */
-#if !defined(__ia64) || (!defined(__hpux) && !defined(__linux__) && !defined(__FreeBSD__))
+#if !defined(__ia64) || (!defined(__hpux) && !defined(__linux__) && !defined(__FreeBSD__) || !defined(__NetBSD__))
 NS_IMETHOD Stub3();
 NS_IMETHOD Stub4();
 NS_IMETHOD Stub5();


### PR DESCRIPTION
This changes let ArctixFox build and run on NetBSD/macppc. 

While there, also apply fixes to other MD implementations.