### PR TITLE
Add Sun Audio support

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -5273,6 +5273,13 @@ if test -n "$MOZ_OMX_PLUGIN"; then
     fi
 fi
 
+dnl If SunOS or NetBSD, assume that Sun Audio is available
+case "$OS_TARGET" in
+SunOS|NetBSD)
+    MOZ_SUN=1
+    ;;
+esac
+
 dnl system libvpx Support
 dnl ========================================================
 MOZ_ARG_WITH_BOOL(system-libvpx,
@@ -5442,6 +5449,8 @@ if test -n "$MOZ_WEBM_ENCODER"; then
     AC_DEFINE(MOZ_WEBM_ENCODER)
 fi
 AC_SUBST(MOZ_WEBM_ENCODER)
+
+AC_SUBST(MOZ_SUN)
 
 dnl ==================================
 dnl = Check alsa availability on Linux
@@ -8852,7 +8861,8 @@ ac_configure_args="$_SUBDIR_CONFIG_ARGS"
 
 # --with-system-nspr will have been converted into the relevant $NSPR_CFLAGS
 # and $NSPR_LIBS.
-ac_configure_args="`echo $ac_configure_args | sed -e 's/--with-system-nspr\S* *//'`"
+ac_configure_args="`echo $ac_configure_args | sed -e 's/--with-system-nspr[[^[:
+space:]]]* *//'`"
 
 ac_configure_args="$ac_configure_args --enable-threadsafe"
 

--- a/media/libcubeb/src/cubeb.c
+++ b/media/libcubeb/src/cubeb.c
@@ -50,6 +50,9 @@ int wasapi_init(cubeb ** context, char const * context_name);
 #if defined(USE_SNDIO)
 int sndio_init(cubeb ** context, char const * context_name);
 #endif
+#if defined(USE_SUN)
+int sun_init(cubeb ** context, char const * context_name);
+#endif
 #if defined(USE_OPENSL)
 int opensl_init(cubeb ** context, char const * context_name);
 #endif
@@ -115,6 +118,9 @@ cubeb_init(cubeb ** context, char const * context_name)
 #endif
 #if defined(USE_SNDIO)
     sndio_init,
+#endif
+#if defined(USE_SUN)
+    sun_init,
 #endif
 #if defined(USE_OPENSL)
     opensl_init,

--- a/media/libcubeb/src/moz.build
+++ b/media/libcubeb/src/moz.build
@@ -25,6 +25,12 @@ if CONFIG['MOZ_PULSEAUDIO']:
     if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'gonk':
         DEFINES['DISABLE_LIBPULSE_DLOPEN'] = True
 
+if CONFIG['MOZ_SUN']:
+    SOURCES += [
+        'cubeb_sun.c',
+    ]
+    DEFINES['USE_SUN'] = True
+
 if CONFIG['OS_ARCH'] == 'OpenBSD':
     SOURCES += [
         'cubeb_sndio.c',


### PR DESCRIPTION
This enables audio on NetbSD.

While there, replace a GNU regex with a portable one.

The patches are from NetBSD's pkgsrc:
http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/www/arcticfox/patches/patch-configure.in?rev=1.1
http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/www/arcticfox/patches/patch-media_libcubeb_src_moz.build?rev=1.1
http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/www/arcticfox/patches/patch-media_libcubeb_src_cubeb.c?rev=1.1